### PR TITLE
Ver 1 0 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,18 @@
-IMPORTANT! Version 0.9.11 compatibility note
-==================
-There might be compatibility issues in you application when you upgrade to this release, so read this section carefully.
-
-Nested.Attribute is deprecated. Use:
-- Nested.options({ ... }) instead of Nested.Attribute({ ... })
-- Type.value( value ) instead of Nested.Attribute( Type, value )
-
-- New semantic for attribute's get and set hooks. Previously, attribute options 'set' and 'get' used to override native properties. Please, refer to "get hook" and "set hook" topics.
-- Model.from and Collection.subsefOf now started with lowercase letter, and will return null and [] when not resolved instead of dummy objects.
-
-Except of these issues, upgrade should go fine. If you will encounter any problems during upgrade which are not covered here, don't hesitate to report a bug.
+0.10.0 Release Notes
+====================
+- attribute get and set hooks
+    - they can be chained now. Thus, they work on Model.from and Collection.subsetOf
+    - they takes attribute name as second argument
+    - fixed bug in set hook (returning undefined didn't prevent attribute modification in some cases)
+- Model
+    - .set now report error when not a plain object is passed as argument.
+    - .deepClone now pass options through the nested calls
+    - Model constructor now pass options to the nested constructors in defaults (except 'parse' and 'collection')
+- Model.from: fixed bug (assignment of the same id to resolved reference caused unnecessary 'change' event)
+- Collection: 'sort' event now doesn't count as nested attribute update, and won't bubble (it caused multiple problems)
+- Collection.subsetOf improvements:
+    - Collections of different types now can be assigned to each other (model arrays will be passed to .set).
+    - Added set manipulation methods: addAll, removeAll, justOne.
 
 backbone.nestedTypes
 ====================
@@ -538,13 +541,13 @@ When attribute is parsed as a part of the model, given function will be called *
 
 #### get hook
 
-    get : function( value ){ return value; }
+    get : function( value, attrName ){ return value; }
 
 Called on Model.get in the context of the model, allowing you to modify returned value.
 
 #### set hook
 
-    set : function( value, options ){ return value; }
+    set : function( value, attrName ){ return value; }
 
 Called on Model.set in the context of the model, allowing you to modify value before set ot cancel setting of the attribute, returning 'undefined'.
 

--- a/README.md
+++ b/README.md
@@ -5,11 +5,15 @@
     - they takes attribute name as second argument
     - fixed bug in set hook (returning undefined didn't prevent attribute modification in some cases)
 - Model
+    - Model.defaults() - added syntax for inline nested model definitions.
+    - .isValid - fixed exception
     - .set now report error when not a plain object is passed as argument.
     - .deepClone now pass options through the nested calls
     - Model constructor now pass options to the nested constructors in defaults (except 'parse' and 'collection')
 - Model.from: fixed bug (assignment of the same id to resolved reference caused unnecessary 'change' event)
-- Collection: 'sort' event now doesn't count as nested attribute update, and won't bubble (it caused multiple problems)
+- Collection:
+    - Collection.defaults() - added syntax for inline nested collection definitions.
+    - 'sort' event now doesn't count as nested attribute update, and won't bubble (it caused multiple problems)
 - Collection.subsetOf improvements:
     - Collections of different types now can be assigned to each other (model arrays will be passed to .set).
     - Added set manipulation methods: addAll, removeAll, justOne.
@@ -479,6 +483,29 @@ var M = Nested.Model.extend({
 		}),
 	}
 });
+```
+### Inline nested Models and Collections definitions
+
+Simple models and collections can be defined with special shortened syntax.
+
+It's useful in case of deeply nested JS objects, when you previously preferred plain objects and arrays in place of models and collections. Now you could easily convert them to nested types, enjoying nested changes detection and 'deep update' features.
+
+```javascript
+var M = Nested.Model.extend({
+    defaults :{
+        nestedModel : Nested.defaults({ // define model extending base Nested.Model
+            a : 1,
+            b : MyModel.defaults({ //define model extending specified model
+                items : Collection.defaults({ // define collection of nested models
+                    a : 1,
+                    b : 2
+                })
+
+            })
+        })
+    }
+})
+
 ```
 
 ### Attribute options

--- a/bower.json
+++ b/bower.json
@@ -18,5 +18,5 @@
         "nestedtypes.js"
     ],
     "license": "MIT",
-    "version": "0.9.11"
+    "version": "0.10.0"
 }

--- a/nestedtypes.js
+++ b/nestedtypes.js
@@ -1,4 +1,4 @@
-// Backbone.nestedTypes 0.9.11 (https://github.com/Volicon/backbone.nestedTypes)
+// Backbone.nestedTypes 0.10.0 (https://github.com/Volicon/backbone.nestedTypes)
 // (c) 2014 Vlad Balin & Volicon, may be freely distributed under the MIT license
 
 // Date.parse with progressive enhancement for ISO 8601 <https://github.com/csnover/js-iso8601>
@@ -39,6 +39,7 @@
     function createExtendFor( Base ){
         return function( protoProps, staticProps ){
             var This = extend.call( this, protoProps, staticProps );
+            delete This._subsetOf;
 
             _.each( protoProps.properties, function( propDesc, name ){
                 var prop = _.isFunction( propDesc ) ? {
@@ -99,6 +100,11 @@
         - transparent typed attributes serialization and deserialization
      **************************************************/
 
+    function chainHooks( first, second ){
+        return function( value, name ){
+            return second.call( this, first.call( this, value, name ), name );
+        }
+    }
     Nested.options = ( function(){
         var Attribute = Nested.Class.extend({
             type : null,
@@ -119,7 +125,7 @@
                     get = this.get;
 
                 spec.get = get ? function(){
-                    return get.call( this, this.attributes[ name ] );
+                    return get.call( this, this.attributes[ name ], name );
                 } : function(){
                     return this.attributes[ name ];
                 };
@@ -128,6 +134,12 @@
             },
 
             options : function( spec ){
+                if( spec.get && this.get ){
+                    spec.get = chainHooks( this.get, spec.get );
+                }
+                if( spec.set && this.set ){
+                    spec.set = chainHooks( this.set, spec.set );
+                }
                 _.extend( this, spec );
                 return this;
             },
@@ -317,7 +329,7 @@
             },
 
             _bulkSet : function( attrs, options ){
-                if( attrs.constructor !== Object ){
+                if( Object.getPrototypeOf( attrs ) !== Object.prototype ){
                     Nested.error.argumentIsNotAnObject( this, attrs );
                 }
 
@@ -332,8 +344,11 @@
                         attrSpec.cast && ( value = attrSpec.cast( value, options, this ) );
 
                         if( attrSpec.set && value !== this.attributes[ name ] ){
-                            value = attrSpec.set.call( this, value, options );
-                            if( value === undefined ) continue;
+                            value = attrSpec.set.call( this, value, name );
+                            if( value === undefined ){
+                                delete attrs[ name ];
+                                continue;
+                            }
                             attrSpec.cast && ( value = attrSpec.cast( value, options, this ) );
                         }
 
@@ -366,7 +381,7 @@
                     attrSpec.cast && ( value = attrSpec.cast( value, options, this ) );
 
                     if( attrSpec.set && value !== this.attributes[ name ] ){
-                        value = attrSpec.set.call( this, value, options );
+                        value = attrSpec.set.call( this, value, name );
                         if( value === undefined ) return this;
                         attrSpec.cast && ( value = attrSpec.cast( value, options, this ) );
                     }
@@ -403,18 +418,30 @@
                 return model.set( attr, value, options );
             },
 
+            constructor : function(attributes, options){
+                var attrs       = attributes || {};
+                options || (options = {});
+                this.cid        = _.uniqueId( 'c' );
+                this.attributes = {};
+                if( options.collection ) this.collection = options.collection;
+                if( options.parse ) attrs = this.parse( attrs, options ) || {};
+                attrs        = _.defaults( {}, attrs, this.defaults( options ) );
+                this.set( attrs, options );
+                this.changed = {};
+                this.initialize.apply( this, arguments );
+            },
             // override get to invoke native getter...
             get : function( name ){ return this[ name ]; },
 
             // Create deep copy for all nested objects...
-            deepClone: function(){
+            deepClone: function( options ){
                 var attrs = {};
 
                 _.each( this.attributes, function( value, key ){
-                    attrs[ key ] = value && value.deepClone ? value.deepClone() : value;
+                    attrs[ key ] = value && value.deepClone ? value.deepClone( options ) : value;
                 });
 
-                return new this.constructor( attrs );
+                return new this.constructor( attrs, options );
             },
 
             // Support for nested models and objects.
@@ -536,13 +563,17 @@
 
             var literals = new Function( 'return {' + json.join( ',' ) + '}' );
 
-            return function(){
+            return function( options ){
+                if( options && ( options.collection || options.parse ) ){
+                    options = _.omit( options, 'collection', 'parse' );
+                }
+
                 var defaults = literals();
 
                 _.extend( defaults, refs );
 
                 for( var name in init ){
-                    defaults[ name ] = init[ name ].create();
+                    defaults[ name ] = init[ name ].create( null, options );
                 }
 
                 return defaults;
@@ -613,7 +644,7 @@
         }
 
         Collection = Backbone.Collection.extend({
-            triggerWhenChanged: 'change add remove reset sort',
+            triggerWhenChanged: 'change add remove reset', // sort
             __class : 'Collection',
 
 			model : Nested.Model,
@@ -636,7 +667,12 @@
 
             __changing: 0,
 
-            set: wrapCall( CollectionProto.set ),
+            set: wrapCall( function( models, options ){
+                if( models && models instanceof Nested.Collection ){
+                    models = models.models;
+                }
+                return CollectionProto.set.call( this, models, options );
+            }),
             remove: wrapCall( CollectionProto.remove ),
             add: wrapCall( CollectionProto.add ),
             reset: wrapCall( CollectionProto.reset ),
@@ -709,7 +745,7 @@
         },
 
         create : function( value, options ){
-            return arguments.length ? new this.type( value, options ) : new this.type();
+            return new this.type( value, options );
         },
 
         cast : function( value, options, model ){
@@ -765,10 +801,7 @@
                     return value && typeof value === 'object' ? value.id : value;
                 },
 
-                property : function( name ){
-                    return {
-                        get : function(){
-                            var objOrId = this.attributes[ name ];
+                get : function( objOrId, name ){
 
                             if( typeof objOrId !== 'object' ){
                                 var master = getMaster.call( this );
@@ -785,12 +818,13 @@
                             return objOrId;
                         },
 
-                        set : function( modelOrId ){
-                            this.set( name, modelOrId );
-
-                            return modelOrId;
+                set : function( modelOrId, name ){
+                    if( typeof modelOrId !== 'object' ){
+                        var current = this.attributes[ name ];
+                        if( current && typeof current === 'object' && current.id === modelOrId ) return;
                         }
-                    }
+
+                    return modelOrId;
                 }
             });
         };
@@ -800,7 +834,7 @@
         var CollectionProto = Nested.Collection.prototype;
 
         var refsCollectionSpec = {
-            triggerWhenChanged : "add remove reset sort",
+            triggerWhenChanged : "add remove reset",
             __class : 'Collection.SubsetOf',
 
             resolvedWith : null,
@@ -838,11 +872,23 @@
                 }
             },
 
+            addAll : function(){
+                this.reset( this.resolvedWith.models );
+            },
+            removeAll : function(){
+                this.reset();
+            },
+            justOne : function( arg ){
+                var model = arg instanceof Backbone.Model ? arg : this.resolvedWith.get( arg );
+                this.set( [ model ] );
+            },
             set : function( models, upperOptions ){
                 var options = { merge : false };
 
+                if( models ){
                 if( models instanceof Array && models.length && typeof models[ 0 ] !== 'object' ){
-                    options.parse = true;
+                        options.merge = options.parse = true;
+                    }
                 }
 
                 CollectionProto.set.call( this, models, _.defaults( options, upperOptions ) );
@@ -863,13 +909,14 @@
         };
 
         return function( masterCollection ){
+            var SubsetOf = this._subsetOf || ( this._subsetOf = this.extend( refsCollectionSpec ) );
             var getMaster = parseReference( masterCollection );
 
             return Nested.options({
-                type : this.extend( refsCollectionSpec ),
+                type : SubsetOf,
 
                 get : function( refs ){
-                    refs.resolvedWith || refs.resolve( getMaster.call( this ) );
+                    !refs || refs.resolvedWith || refs.resolve( getMaster.call( this ) );
                     return refs;
                 }
             });

--- a/package.json
+++ b/package.json
@@ -18,5 +18,5 @@
         "nestedtypes.js"
     ],
     "license": "MIT",
-    "version": "0.9.11"
+    "version": "0.10.0"
 }

--- a/tests/backboneTypes.js
+++ b/tests/backboneTypes.js
@@ -45,8 +45,15 @@ define( function( require, exports, module ){
             var collection = sinon.spy(),
                 model = sinon.spy();
 
-            A.Collection.prototype.parse = function( data ){ collection(); return data; }
-            A.prototype.parse = function( data ){ model(); return data; };
+            A.Collection.prototype.parse = function( data ){
+                collection();
+                return data;
+            };
+
+            A.prototype.parse = function( data ){
+                model();
+                return data;
+            };
 
             return { model : model, collection : collection };
         }

--- a/tests/relations.js
+++ b/tests/relations.js
@@ -205,11 +205,6 @@ define( function( require, exports, module ){
             expect( Nested.store.resolved.roles ).to.be.true;
         });
 
-        it( 'uses real collection types for subsetOf attributes', function(){
-            expect( Nested.store.users.first().roles ).to.be.instanceOf( Role.Collection );
-            expect( Nested.store.roles.first().users ).to.be.instanceOf( User.Collection );
-        });
-
         it( 'individual elements can be cleaned up ', function(){
             Nested.store.clear( 'users' );
             expect( Nested.store.resolved.users ).to.be.not.ok;

--- a/tests/types.js
+++ b/tests/types.js
@@ -283,10 +283,11 @@ define( function( require, exports, module ){
                 var A = Nested.Model.extend({
                     defaults : {
                         a : Number.options({
+                            value : 33,
                             set : function( value, options ){
                                 expect( value ).to.be.a( 'number' );
 
-                                if( !options || !options.doNothing ){
+                                if( value !== 0 ){
                                     return value * 2;
                                 }
                             }
@@ -321,9 +322,9 @@ define( function( require, exports, module ){
 
                 it( 'may prevent attribute\'s assignment', function(){
                     var m = new A();
-                    m.set( 'a', 5, { doNothing : true } );
+                    m.set( 'a', 0 );
 
-                    expect( m.a ).to.be.equal( 0 );
+                    expect( m.a ).to.be.equal( 66 );
                 });
             });
 


### PR DESCRIPTION
- attribute get and set hooks
    - they can be chained now. Thus, they work on Model.from and Collection.subsetOf
    - they takes attribute name as second argument
    - fixed bug in set hook (returning undefined didn't prevent attribute modification in some cases)
- Model
    - Model.defaults() - added syntax for inline nested model definitions.
    - .isValid - fixed exception
    - .set now report error when not a plain object is passed as argument.
    - .deepClone now pass options through the nested calls
    - Model constructor now pass options to the nested constructors in defaults (except 'parse' and 'collection')
- Model.from: fixed bug (assignment of the same id to resolved reference caused unnecessary 'change' event)
- Collection:
    - Collection.defaults() - added syntax for inline nested collection definitions.
    - 'sort' event now doesn't count as nested attribute update, and won't bubble (it caused multiple problems)
- Collection.subsetOf improvements:
    - Collections of different types now can be assigned to each other (model arrays will be passed to .set).
    - Added set manipulation methods: addAll, removeAll, justOne.
