### PR TITLE
Fix issue #85

### DIFF
--- a/chaplinjs/nestedtypes.js
+++ b/chaplinjs/nestedtypes.js
@@ -315,13 +315,15 @@ var Attribute = Object.extend( {
                 Type.attribute = Type.options = options;
                 Type.value = value;
                 Type.Attribute = this;
-                Object.defineProperty( Type, 'has', {
-                    get : function(){
-                        // workaround for sinon.js and other libraries overriding 'has'
-                        return this._has || this.options();
-                    },
-                    set : function( value ){ this._has = value; }
-                } );
+                if (typeof(Type.has) === 'undefined') {
+                    Object.defineProperty( Type, 'has', {
+                        get : function(){
+                            // workaround for sinon.js and other libraries overriding 'has'
+                            return this._has || this.options();
+                        },
+                        set : function( value ){ this._has = value; }
+                    } );
+                }
             }
         };
     })()

--- a/nestedtypes.js
+++ b/nestedtypes.js
@@ -310,13 +310,15 @@ var Attribute = Object.extend( {
                 Type.attribute = Type.options = options;
                 Type.value = value;
                 Type.Attribute = this;
-                Object.defineProperty( Type, 'has', {
-                    get : function(){
-                        // workaround for sinon.js and other libraries overriding 'has'
-                        return this._has || this.options();
-                    },
-                    set : function( value ){ this._has = value; }
-                } );
+                if (typeof(Type.has) === 'undefined') {
+                    Object.defineProperty( Type, 'has', {
+                        get : function(){
+                            // workaround for sinon.js and other libraries overriding 'has'
+                            return this._has || this.options();
+                        },
+                        set : function( value ){ this._has = value; }
+                    } );
+                }
             }
         };
     })()

--- a/src/attribute.js
+++ b/src/attribute.js
@@ -284,13 +284,15 @@ var Attribute = Object.extend( {
                 Type.attribute = Type.options = options;
                 Type.value = value;
                 Type.Attribute = this;
-                Object.defineProperty( Type, 'has', {
-                    get : function(){
-                        // workaround for sinon.js and other libraries overriding 'has'
-                        return this._has || this.options();
-                    },
-                    set : function( value ){ this._has = value; }
-                } );
+                if (typeof(Type.has) === 'undefined') {
+                    Object.defineProperty( Type, 'has', {
+                        get : function(){
+                            // workaround for sinon.js and other libraries overriding 'has'
+                            return this._has || this.options();
+                        },
+                        set : function( value ){ this._has = value; }
+                    } );
+                }
             }
         };
     })()


### PR DESCRIPTION
Changes Attribute.attach to only define the 'has' property if it doesn't already exist.

Note: I'm not sure why this is actually even needed. I don't see Type.has referenced anywhere. Where is this code from?