### PR TITLE
NestedTypes meets transactions

### DIFF
--- a/chaplinjs/nestedtypes.js
+++ b/chaplinjs/nestedtypes.js
@@ -1222,7 +1222,7 @@ function setSingleAttr( model, key, value, attrSpec ){
 // model.set inside of a_fun will trigger change:attr
 // but only single 'change' will be triggered at the end of transaction
 // transactions can be nested
-function transaction( a_fun, args ){
+function transaction( a_fun, context, args ){
     var notChanging = !this._changing,
         options  = {};
 
@@ -1235,7 +1235,7 @@ function transaction( a_fun, args ){
     }
 
     this.__begin();
-    var res = a_fun.apply( this, args );
+    var res = a_fun.apply( context || this, args );
     this.__commit();
 
     if( notChanging ){
@@ -1831,7 +1831,7 @@ Object.assign( exports, {
 
     transaction : function( fun ){
         return function(){
-            return this.transaction( fun, arguments );
+            return this.transaction( fun, this, arguments );
         }
     }
 });

--- a/chaplinjs/nestedtypes.js
+++ b/chaplinjs/nestedtypes.js
@@ -777,6 +777,8 @@ var Model = BaseModel.extend( {
     __begin  : modelSet.__begin,
     __commit : modelSet.__commit,
 
+    transaction : modelSet.transaction,
+
     set : function( a, b, c ){
         switch( typeof a ){
         case 'string' :
@@ -1165,9 +1167,10 @@ module.exports = {
     isChanged     : genericIsChanged,
     setSingleAttr : setSingleAttr,
     setAttrs      : setAttrs,
+    transaction   : transaction,
     transform     : applyTransform,
-    __begin         : __begin,
-    __commit        : __commit
+    __begin       : __begin,
+    __commit      : __commit
 };
 
 function genericIsChanged( a, b ){
@@ -1183,7 +1186,7 @@ function setSingleAttr( model, key, value, attrSpec ){
 
     if( !changing ){
         model._previousAttributes = new model.Attributes( current );
-        model.changed = {};
+        model.changed             = {};
     }
 
     var prev      = model._previousAttributes,
@@ -1204,14 +1207,49 @@ function setSingleAttr( model, key, value, attrSpec ){
     }
 
     while( model._pending ){
-        options = model._pending;
+        options        = model._pending;
         model._pending = false;
         trigger2( model, 'change', model, options );
     }
 
-    model._pending = false;
+    model._pending  = false;
     model._changing = false;
     return model;
+}
+
+
+// call a_fun with a_args inside of set transaction.
+// model.set inside of a_fun will trigger change:attr
+// but only single 'change' will be triggered at the end of transaction
+// transactions can be nested
+function transaction( a_fun, args ){
+    var notChanging = !this._changing,
+        options  = {};
+
+    this._changing = true;
+
+
+    if( notChanging ){
+        this._previousAttributes = new this.Attributes( this.attributes );
+        this.changed             = {};
+    }
+
+    this.__begin();
+    var res = a_fun.apply( this, args );
+    this.__commit();
+
+    if( notChanging ){
+        while( this._pending ){
+            options       = this._pending;
+            this._pending = false;
+            trigger2( this, 'change', this, options );
+        }
+
+        this._pending  = false;
+        this._changing = false;
+    }
+
+    return res;
 }
 
 // General case set: used for multiple and nested model/collection attributes.
@@ -1238,7 +1276,7 @@ function bbSetAttrs( model, attrs, opts ){
 
     if( !changing ){
         model._previousAttributes = new model.Attributes( current );
-        model.changed = {};
+        model.changed             = {};
     }
 
     var prev = model._previousAttributes;
@@ -1281,17 +1319,17 @@ function bbSetAttrs( model, attrs, opts ){
     }
     if( !silent ){
         while( model._pending ){
-            options = model._pending;
+            options        = model._pending;
             model._pending = false;
             trigger2( model, 'change', model, options );
         }
     }
 
-    model._pending = false;
+    model._pending  = false;
     model._changing = false;
 
     return model;
-};
+}
 
 // Optimized Backbone Core functions
 // =================================
@@ -1789,6 +1827,12 @@ Object.assign( exports, {
 
     defaults   : function( x ){
         return Model.defaults( x );
+    },
+
+    transaction : function( fun ){
+        return function(){
+            return this.transaction( fun, arguments );
+        }
     }
 });
 },{"./attribute":1,"./collection":3,"./errors":4,"./metatypes":5,"./model":6,"./object+":8,"./relations":9,"./store":10}]},{},[]);

--- a/nestedtypes.js
+++ b/nestedtypes.js
@@ -1217,7 +1217,7 @@ function setSingleAttr( model, key, value, attrSpec ){
 // model.set inside of a_fun will trigger change:attr
 // but only single 'change' will be triggered at the end of transaction
 // transactions can be nested
-function transaction( a_fun, args ){
+function transaction( a_fun, context, args ){
     var notChanging = !this._changing,
         options  = {};
 
@@ -1230,7 +1230,7 @@ function transaction( a_fun, args ){
     }
 
     this.__begin();
-    var res = a_fun.apply( this, args );
+    var res = a_fun.apply( context || this, args );
     this.__commit();
 
     if( notChanging ){
@@ -1826,7 +1826,7 @@ Object.assign( exports, {
 
     transaction : function( fun ){
         return function(){
-            return this.transaction( fun, arguments );
+            return this.transaction( fun, this, arguments );
         }
     }
 });

--- a/performance.js
+++ b/performance.js
@@ -11,6 +11,34 @@ define( function( require, exports, module ){
                     defaults : {
                         a1 : 1, a2 : 2, a3 : 3, a4: 4, a5 : 5, a6: 6, a7: 7, a8: 8, a9: 9, a10 : 10,
                         b1 : 1, b2 : 2, b3 : 3, b4: 4, b5 : 5, b6: 6, b7: 7, b8: 8, b9: 9, b10 : 10
+                    },
+
+                    updateSet : function(){
+                        this.set({
+                            a1 : this.a1 + 1,
+                            a2 : this.a2 + 1,
+                            a3 : this.a3 + 1,
+                            a4 : this.a4 + 1,
+                            a5 : this.a5 + 1
+                        });
+                    },
+
+                    updateTransaction : Nested.transaction(function(){
+                        this.a1 = this.a1 + 1;
+                        this.a2 = this.a2 + 1;
+                        this.a3 = this.a3 + 1;
+                        this.a4 = this.a4 + 1;
+                        this.a5 = this.a5 + 1;
+                    }),
+
+                    updateAdHocTransaction : function(){
+                        this.transaction( function(){
+                            this.a1 = this.a1 + 1;
+                            this.a2 = this.a2 + 1;
+                            this.a3 = this.a3 + 1;
+                            this.a4 = this.a4 + 1;
+                            this.a5 = this.a5 + 1;
+                        });
                     }
                 });
 
@@ -18,6 +46,16 @@ define( function( require, exports, module ){
                     defaults : {
                         a1 : 1, a2 : 2, a3 : 3, a4: 4, a5 : 5, a6: 6, a7: 7, a8: 8, a9: 9, a10 : 10,
                         b1 : 1, b2 : 2, b3 : 3, b4: 4, b5 : 5, b6: 6, b7: 7, b8: 8, b9: 9, b10 : 10
+                    },
+
+                    updateSet : function(){
+                        this.set({
+                            a1 : this.a1 + 1,
+                            a2 : this.a2 + 1,
+                            a3 : this.a3 + 1,
+                            a4 : this.a4 + 1,
+                            a5 : this.a5 + 1
+                        });
                     }
                 });
 
@@ -179,6 +217,42 @@ define( function( require, exports, module ){
                     for( var i = 0; i < 1000000; i++ ){
                         l.a1 = l.a1 + 1;
                         s.a1 = l.a1 + 1;
+                    }
+                });
+            });
+
+            describe( '1M 5-attr transactional updates', function(){
+                makeDefinitions();
+
+                it( 'Backbone', function(){
+                    var l = new BLarge();
+
+                    for( var i = 0; i < 1000000; i++ ){
+                        l.updateSet();
+                    }
+                });
+
+                it( 'Nested', function(){
+                    var l = new NLarge();
+
+                    for( var i = 0; i < 1000000; i++ ){
+                        l.updateSet();
+                    }
+                });
+
+                it( 'Nested transaction', function(){
+                    var l = new NLarge();
+
+                    for( var i = 0; i < 1000000; i++ ){
+                        l.updateTransaction();
+                    }
+                });
+
+                it( 'Nested AdHoc transaction', function(){
+                    var l = new NLarge();
+
+                    for( var i = 0; i < 1000000; i++ ){
+                        l.updateAdHocTransaction();
                     }
                 });
             });

--- a/performance.js
+++ b/performance.js
@@ -50,11 +50,11 @@ define( function( require, exports, module ){
 
                     updateSet : function(){
                         this.set({
-                            a1 : this.a1 + 1,
-                            a2 : this.a2 + 1,
-                            a3 : this.a3 + 1,
-                            a4 : this.a4 + 1,
-                            a5 : this.a5 + 1
+                            a1 : this.get( 'a1' ) + 1,
+                            a2 : this.get( 'a2' ) + 1,
+                            a3 : this.get( 'a3' ) + 1,
+                            a4 : this.get( 'a4' ) + 1,
+                            a5 : this.get( 'a5' ) + 1
                         });
                     }
                 });

--- a/src/main.js
+++ b/src/main.js
@@ -33,7 +33,7 @@ Object.assign( exports, {
 
     transaction : function( fun ){
         return function(){
-            return this.transaction( fun, arguments );
+            return this.transaction( fun, this, arguments );
         }
     }
 });

--- a/src/main.js
+++ b/src/main.js
@@ -29,5 +29,11 @@ Object.assign( exports, {
 
     defaults   : function( x ){
         return Model.defaults( x );
+    },
+
+    transaction : function( fun ){
+        return function(){
+            return this.transaction( fun, arguments );
+        }
     }
 });

--- a/src/model.js
+++ b/src/model.js
@@ -46,6 +46,8 @@ var Model = BaseModel.extend( {
     __begin  : modelSet.__begin,
     __commit : modelSet.__commit,
 
+    transaction : modelSet.transaction,
+
     set : function( a, b, c ){
         switch( typeof a ){
         case 'string' :

--- a/src/modelset.js
+++ b/src/modelset.js
@@ -85,7 +85,7 @@ function setSingleAttr( model, key, value, attrSpec ){
 // model.set inside of a_fun will trigger change:attr
 // but only single 'change' will be triggered at the end of transaction
 // transactions can be nested
-function transaction( a_fun, args ){
+function transaction( a_fun, context, args ){
     var notChanging = !this._changing,
         options  = {};
 
@@ -98,7 +98,7 @@ function transaction( a_fun, args ){
     }
 
     this.__begin();
-    var res = a_fun.apply( this, args );
+    var res = a_fun.apply( context || this, args );
     this.__commit();
 
     if( notChanging ){

--- a/src/modelset.js
+++ b/src/modelset.js
@@ -85,19 +85,21 @@ function setSingleAttr( model, key, value, attrSpec ){
 // model.set inside of a_fun will trigger change:attr
 // but only single 'change' will be triggered at the end of transaction
 // transactions can be nested
-function transaction( a_fun, a_args ){
+function transaction( a_fun, args ){
     var notChanging = !this._changing,
-        args     = a_args || [],
         options  = {};
 
     this._changing = true;
+
 
     if( notChanging ){
         this._previousAttributes = new this.Attributes( this.attributes );
         this.changed             = {};
     }
 
+    this.__begin();
     var res = a_fun.apply( this, args );
+    this.__commit();
 
     if( notChanging ){
         while( this._pending ){

--- a/test/backboneTypes.js
+++ b/test/backboneTypes.js
@@ -224,6 +224,28 @@
                 });
             });
 
+            it( 'send single "change" event in a transaction', function(){
+                var m = new B();
+
+                shouldFireChangeOnce( m, 'first', function(){
+                    m.first.transaction( function(){
+                        this.a = 7;
+                        this.b = 7;
+                    });
+                });
+            });
+
+            it( 'send single "change" event in a nested transaction', function(){
+                var m = new B();
+
+                shouldFireChangeOnce( m, 'first', function(){
+                    m.transaction( function(){
+                        m.first.a = 7;
+                        m.first.b = 7;
+                    });
+                });
+            });
+
             it( 'generate "change" event on any nested collection modification', function(){
                 var m = new B();
 


### PR DESCRIPTION
Transactions allow to group the series of model updates in the way that it will trigger just single change event.

It dramatically boost performance in case of native props are being used for complex updates.

Finally, we don't need 'set' any more.
